### PR TITLE
fix minor problem with the version string for hadoop-common

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -69,7 +69,7 @@
       conf="jetty->master"/>
     <dependency org="org.apache.hadoop"
       name="hadoop-common"
-      rev="0.22.0-SNAPSHOT"
+      rev="0.22.0"
       conf="common->default"/>
     <dependency org="org.mortbay.jetty"
       name="servlet-api-2.5"


### PR DESCRIPTION
The maven2 repository replaced 0.22.0-SNAPSHOT with 0.22.0.

(current version string gives a 404 error)
