### PR TITLE
Updated Lzop to return the correct decompressor type.

### DIFF
--- a/src/java/com/hadoop/compression/lzo/LzopCodec.java
+++ b/src/java/com/hadoop/compression/lzo/LzopCodec.java
@@ -82,6 +82,7 @@ public class LzopCodec extends LzoCodec {
         getConf().getInt("io.compression.codec.lzo.buffersize", 256 * 1024));
   }
 
+  @Override
   public Decompressor createDecompressor() {
     if (!isNativeLzoLoaded(getConf())) {
       throw new RuntimeException("native-lzo library not available");
@@ -89,6 +90,15 @@ public class LzopCodec extends LzoCodec {
     return new LzopDecompressor(getConf().getInt(
           "io.compression.codec.lzo.buffersize", 256 * 1024));
   }
+
+  public Class<? extends Decompressor> getDecompressorType() {
+    // Ensure native-lzo library is loaded & initialized
+    if (!isNativeLzoLoaded(getConf())) {
+      throw new RuntimeException("native-lzo library not available");
+    }
+    return LzopDecompressor.class;
+  }
+
 
   public String getDefaultExtension() {
     return ".lzo";


### PR DESCRIPTION
This fixes 

https://github.com/omalley/hadoop-gpl-compression/issues/3

I tested it manually with a word count job that spills more than once in the map and has 1000 reducers.  If you set 

-Dmapreduce.map.output.compress.codec=com.hadoop.compression.lzo.LzopCodec

before this change the process will OOM.  After the change it completes successfully.
